### PR TITLE
Fix chat separation, death messages, and stats tracking

### DIFF
--- a/Funcraft/src/main/java/fr/cronowz/blitz2v2/Blitz2v2.java
+++ b/Funcraft/src/main/java/fr/cronowz/blitz2v2/Blitz2v2.java
@@ -3,9 +3,9 @@ package fr.cronowz.blitz2v2;
 
 import fr.cronowz.blitz2v2.commands.HubCommand;
 import fr.cronowz.blitz2v2.commands.SpawnCommand;
+import fr.cronowz.blitz2v2.commands.StatsCommand;
 import fr.cronowz.blitz2v2.game.GameRulesListener;
 import fr.cronowz.blitz2v2.game.KitService;
-import fr.cronowz.blitz2v2.listeners.ChatListener;
 import fr.cronowz.blitz2v2.listeners.CommandRestrictionListener;
 import fr.cronowz.blitz2v2.listeners.CombatListener;
 import fr.cronowz.blitz2v2.listeners.CompassMenuListener;
@@ -23,6 +23,8 @@ import fr.cronowz.blitz2v2.listeners.WaitingRoomListener;
 import fr.cronowz.blitz2v2.listeners.WaitingRoomVoidListener;
 import fr.cronowz.blitz2v2.listeners.WeatherLockListener;
 import fr.cronowz.blitz2v2.manager.GameManager;
+import fr.cronowz.blitz2v2.combat.CombatTrackerListener;
+import fr.cronowz.blitz2v2.stats.KillStatsManager;
 import fr.cronowz.blitz2v2.protect.ProtectionListener;
 import fr.cronowz.blitz2v2.protect.ProtectionManager;
 import fr.cronowz.blitz2v2.protect.SelectionManager;
@@ -42,6 +44,7 @@ public class Blitz2v2 extends JavaPlugin {
 
     private GameManager       gameManager;
     private KitService        kitService;
+    private KillStatsManager  killStatsManager;
     private FileConfiguration cfg;
     private String            gameWorldName;
     private Location          lobbySpawn;
@@ -73,8 +76,9 @@ public class Blitz2v2 extends JavaPlugin {
 
         int potatoAmount = cfg.getInt("kit.potatoes", 12);
         int pickDur      = cfg.getInt("kit.pickaxe-remaining-durability", 20);
-        this.kitService  = new KitService(potatoAmount, pickDur);
-        this.gameManager = new GameManager();
+        this.kitService       = new KitService(potatoAmount, pickDur);
+        this.gameManager      = new GameManager();
+        this.killStatsManager = new KillStatsManager(getDataFolder());
 
         // Nettoyage en cas de /reload
         HandlerList.unregisterAll(this);
@@ -97,9 +101,9 @@ public class Blitz2v2 extends JavaPlugin {
         pm.registerEvents(new InventoryProtectionListener(), this);
         pm.registerEvents(new CompassMenuListener(),       this);
         pm.registerEvents(new SubMenuListener(),           this);
-        pm.registerEvents(new ChatListener(),              this);
         pm.registerEvents(new CommandRestrictionListener(), this);
         pm.registerEvents(new CombatListener(),            this);
+        pm.registerEvents(new CombatTrackerListener(killStatsManager), this);
         pm.registerEvents(new TeamFriendlyFireListener(),  this);
         pm.registerEvents(new WaitingRoomVoidListener(),   this);
         pm.registerEvents(new PartyListener(),             this);
@@ -128,6 +132,7 @@ public class Blitz2v2 extends JavaPlugin {
         }
         if (getCommand("hub")   != null) getCommand("hub").setExecutor(new HubCommand());
         if (getCommand("spawn") != null) getCommand("spawn").setExecutor(new SpawnCommand());
+        if (getCommand("stats") != null) getCommand("stats").setExecutor(new StatsCommand(killStatsManager));
 
         getLogger().info("Blitz2v2 activé !");
     }
@@ -136,6 +141,7 @@ public class Blitz2v2 extends JavaPlugin {
     public void onDisable() {
         HandlerList.unregisterAll(this);
         Bukkit.getScheduler().cancelTasks(this);
+        if (killStatsManager != null) killStatsManager.save();
         getLogger().info("Blitz2v2 désactivé.");
     }
 

--- a/Funcraft/src/main/java/fr/cronowz/blitz2v2/commands/StatsCommand.java
+++ b/Funcraft/src/main/java/fr/cronowz/blitz2v2/commands/StatsCommand.java
@@ -45,7 +45,6 @@ public class StatsCommand implements CommandExecutor {
 
         sender.sendMessage(ChatColor.GOLD + "Statistiques de " + ChatColor.WHITE + target.getName());
         sender.sendMessage(ChatColor.YELLOW + "Kills: " + ChatColor.WHITE + s.kills
-                + ChatColor.YELLOW + " | Assists: " + ChatColor.WHITE + s.assists
                 + ChatColor.YELLOW + " | Morts: " + ChatColor.WHITE + s.deaths);
         sender.sendMessage(ChatColor.YELLOW + "K/D: " + ChatColor.WHITE + String.format(java.util.Locale.US, "%.2f", kd));
         return true;

--- a/Funcraft/src/main/java/fr/cronowz/blitz2v2/listeners/JoinListener.java
+++ b/Funcraft/src/main/java/fr/cronowz/blitz2v2/listeners/JoinListener.java
@@ -99,12 +99,12 @@ public class JoinListener implements Listener {
         obj.getScore("§fMode: §eLobby").setScore(line--);
         obj.getScore("§fEn ligne: §a" + Bukkit.getOnlinePlayers().size()
                 + "§7/" + Bukkit.getMaxPlayers()).setScore(line--);
-        obj.getScore(" ").setScore(line--);
-        obj.getScore(" ").setScore(line--);
-        obj.getScore(" ").setScore(line--);
+        obj.getScore("  ").setScore(line--);   // lignes vides uniques
+        obj.getScore("   ").setScore(line--);
+        obj.getScore("    ").setScore(line--);
         obj.getScore("§fJoueur: §a" + p.getName()).setScore(line--);
         obj.getScore("§fVisitez: §bplexymc.org").setScore(line--);
-        obj.getScore("  ").setScore(line);
+        obj.getScore("     ").setScore(line);
 
         p.setScoreboard(board);
     }

--- a/Funcraft/src/main/java/fr/cronowz/blitz2v2/stats/KillStatsManager.java
+++ b/Funcraft/src/main/java/fr/cronowz/blitz2v2/stats/KillStatsManager.java
@@ -13,7 +13,6 @@ public class KillStatsManager {
     public static class Stats {
         public int kills;
         public int deaths;
-        public int assists;
     }
 
     private final Map<UUID, Stats> data = new HashMap<>();
@@ -30,15 +29,13 @@ public class KillStatsManager {
 
     public void addKill(UUID id)    { get(id).kills++; }
     public void addDeath(UUID id)   { get(id).deaths++; }
-    public void addAssist(UUID id)  { get(id).assists++; }
 
     public void save() {
         YamlConfiguration y = new YamlConfiguration();
         for (Map.Entry<UUID, Stats> e : data.entrySet()) {
             String k = e.getKey().toString();
-            y.set(k + ".kills",   e.getValue().kills);
-            y.set(k + ".deaths",  e.getValue().deaths);
-            y.set(k + ".assists", e.getValue().assists);
+            y.set(k + ".kills",  e.getValue().kills);
+            y.set(k + ".deaths", e.getValue().deaths);
         }
         try { y.save(file); } catch (IOException ignored) {}
     }
@@ -51,9 +48,8 @@ public class KillStatsManager {
             try {
                 UUID id = UUID.fromString(k);
                 Stats s = new Stats();
-                s.kills   = y.getInt(k + ".kills", 0);
-                s.deaths  = y.getInt(k + ".deaths", 0);
-                s.assists = y.getInt(k + ".assists", 0);
+                s.kills  = y.getInt(k + ".kills", 0);
+                s.deaths = y.getInt(k + ".deaths", 0);
                 data.put(id, s);
             } catch (Exception ignored) {}
         }


### PR DESCRIPTION
## Summary
- ensure team/global chat works by removing old chat listener
- distribute kill credit to multiple attackers with death messages
- remove assists and add `/stats` command using persistent kill/death stats
- make lobby scoreboard blank lines unique to avoid disappearing

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a08ee92e14832d9575cb723978b02d